### PR TITLE
Init

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "symfony/http-kernel": "^5.4|^6.4|^7.1",
         "symfony/framework-bundle": "^5.4|^6.4|^7.1",
         "symfony/dependency-injection": "^5.4|^6.4|^7.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,3 +13,7 @@ parameters:
             message: '#.* has no value type specified in iterable type array#'
         -
             message: '#.* has parameter .* with no value type specified in iterable type array#'
+        # Logger trait can be null before injection
+        -
+            message: '#Cannot call method .* on Psr\\Log\\LoggerInterface\|null#'
+            path: src/Service/PerspectiveApiService.php

--- a/src/Service/PerspectiveApiService.php
+++ b/src/Service/PerspectiveApiService.php
@@ -23,6 +23,15 @@ class PerspectiveApiService
         'THREAT',
     ];
 
+    private const DEFAULT_FALLBACK_THRESHOLDS = [
+        'TOXICITY' => 0.7,
+        'SEVERE_TOXICITY' => 0.5,
+        'IDENTITY_ATTACK' => 0.6,
+        'INSULT' => 0.6,
+        'PROFANITY' => 0.8,
+        'THREAT' => 0.5,
+    ];
+
     private ?ThresholdProviderInterface $thresholdProvider = null;
     private mixed $thresholdResolver = null;
     private array $staticThresholds = [];
@@ -179,7 +188,16 @@ class PerspectiveApiService
             return $this->validateThresholds($this->thresholdProvider->getThresholds());
         }
 
-        return $this->validateThresholds($this->staticThresholds);
+        $thresholds = $this->validateThresholds($this->staticThresholds);
+
+        if (empty($thresholds)) {
+            $thresholds = array_intersect_key(
+                self::DEFAULT_FALLBACK_THRESHOLDS,
+                array_flip($this->analyzeAttributes)
+            );
+        }
+
+        return $thresholds;
     }
 
     private function validateThresholds(array $thresholds): array

--- a/src/Service/PerspectiveApiService.php
+++ b/src/Service/PerspectiveApiService.php
@@ -7,11 +7,15 @@ namespace Freema\PerspectiveApiBundle\Service;
 use Freema\PerspectiveApiBundle\Contract\ThresholdProviderInterface;
 use Freema\PerspectiveApiBundle\Dto\PerspectiveAnalysisResult;
 use Freema\PerspectiveApiBundle\Exception\PerspectiveApiException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-class PerspectiveApiService
+class PerspectiveApiService implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
     private const API_BASE_URL = 'https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze';
 
     private const DEFAULT_ATTRIBUTES = [
@@ -50,6 +54,7 @@ class PerspectiveApiService
         $this->staticThresholds = $config['thresholds'] ?? [];
         $this->analyzeAttributes = $config['analyze_attributes'] ?? self::DEFAULT_ATTRIBUTES;
         $this->defaultLanguage = $config['default_language'] ?? 'en';
+        $this->logger = new NullLogger();
     }
 
     public function setThresholdProvider(ThresholdProviderInterface $provider): self
@@ -72,10 +77,25 @@ class PerspectiveApiService
         ?array $customThresholds = null,
         array $context = [],
     ): PerspectiveAnalysisResult {
+        $this->logger->debug('Starting Perspective API text analysis', [
+            'text_length' => strlen($text),
+            'language' => $language ?? $this->defaultLanguage,
+            'custom_thresholds_provided' => $customThresholds !== null,
+            'context_keys' => array_keys($context),
+        ]);
+
         $scores = $this->getScores($text, $language);
         $thresholds = $this->resolveThresholds($customThresholds, $context);
+        $result = new PerspectiveAnalysisResult($scores, $thresholds);
 
-        return new PerspectiveAnalysisResult($scores, $thresholds);
+        $this->logger->info('Perspective API analysis completed', [
+            'scores' => $scores,
+            'thresholds' => $thresholds,
+            'violations' => array_keys($result->getViolations()),
+            'is_acceptable' => $result->isAllowed(),
+        ]);
+
+        return $result;
     }
 
     public function getScores(string $text, ?string $language = null): array
@@ -145,12 +165,20 @@ class PerspectiveApiService
         $statusCode = $response->getStatusCode();
 
         if (200 !== $statusCode) {
-            throw PerspectiveApiException::apiRequestFailed(sprintf('HTTP %d: %s', $statusCode, $response->getContent(false)));
+            $errorContent = $response->getContent(false);
+            $this->logger->error('Perspective API request failed', [
+                'status_code' => $statusCode,
+                'response' => $errorContent,
+            ]);
+            throw PerspectiveApiException::apiRequestFailed(sprintf('HTTP %d: %s', $statusCode, $errorContent));
         }
 
         $data = $response->toArray();
 
         if (!isset($data['attributeScores'])) {
+            $this->logger->error('Invalid Perspective API response', [
+                'response_data' => $data,
+            ]);
             throw PerspectiveApiException::invalidApiResponse('Missing attributeScores in response');
         }
 
@@ -195,6 +223,11 @@ class PerspectiveApiService
                 self::DEFAULT_FALLBACK_THRESHOLDS,
                 array_flip($this->analyzeAttributes)
             );
+
+            $this->logger->info('Using fallback thresholds for Perspective API analysis', [
+                'attributes' => array_keys($thresholds),
+                'thresholds' => $thresholds,
+            ]);
         }
 
         return $thresholds;
@@ -206,6 +239,10 @@ class PerspectiveApiService
 
         foreach ($thresholds as $attribute => $threshold) {
             if (!is_numeric($threshold) || $threshold < 0.0 || $threshold > 1.0) {
+                $this->logger->error('Invalid threshold value detected', [
+                    'attribute' => $attribute,
+                    'threshold' => $threshold,
+                ]);
                 throw PerspectiveApiException::invalidThresholdValue($attribute, (float) $threshold);
             }
 


### PR DESCRIPTION
This pull request enhances the `PerspectiveApiService` by adding robust logging and improved threshold handling. The main improvements are the integration of PSR-3 logging, more informative error and debug logs throughout the service, and the introduction of fallback threshold values to ensure reliable operation when no custom or static thresholds are provided.

**Logging Integration and Error Reporting:**
* Added PSR-3 logging support to `PerspectiveApiService` by implementing `LoggerAwareInterface`, using `LoggerAwareTrait`, and initializing with `NullLogger` for default safety. [[1]](diffhunk://#diff-4bc5cee33654e22cca9eef257a69439f15c3f70964fa4c8704241ae071e94bfaR10-R18) [[2]](diffhunk://#diff-4bc5cee33654e22cca9eef257a69439f15c3f70964fa4c8704241ae071e94bfaR57) [[3]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R29)
* Inserted debug and info log statements in the `analyzeText` method to provide visibility into the analysis process, including input details and analysis results.
* Enhanced error reporting in API response parsing and threshold validation by logging errors before throwing exceptions, improving traceability of failures. [[1]](diffhunk://#diff-4bc5cee33654e22cca9eef257a69439f15c3f70964fa4c8704241ae071e94bfaL139-R181) [[2]](diffhunk://#diff-4bc5cee33654e22cca9eef257a69439f15c3f70964fa4c8704241ae071e94bfaR242-R245)

**Threshold Handling Improvements:**
* Introduced `DEFAULT_FALLBACK_THRESHOLDS` to ensure sensible defaults are used when no thresholds are configured, and log when fallbacks are applied. [[1]](diffhunk://#diff-4bc5cee33654e22cca9eef257a69439f15c3f70964fa4c8704241ae071e94bfaR30-R38) [[2]](diffhunk://#diff-4bc5cee33654e22cca9eef257a69439f15c3f70964fa4c8704241ae071e94bfaL182-R233)

**Configuration and Static Analysis:**
* Updated `composer.json` to require `psr/log` for logging support.
* Adjusted `phpstan.neon` to suppress static analysis warnings related to nullable logger usage in the service.