### PR TITLE
feat: Add support for custom HTTP client options in PerspectiveApiSer…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,43 @@ This change reflects Google's commitment to improving the API with cutting-edge 
 - Symfony 5.4, 6.x, or 7.x
 - Google Perspective API key ([Get one here](https://developers.perspectiveapi.com/s/docs-get-started))
 
+## 🔧 Advanced Configuration
+
+### HTTP Client Options
+
+The bundle supports custom HTTP client configuration for environments that require proxy servers or specific timeouts:
+
+```yaml
+# config/packages/perspective_api.yaml
+perspective_api:
+    api_key: '%env(PERSPECTIVE_API_KEY)%'
+    
+    # Configure HTTP client options
+    http_client_options:
+        # Use proxy server
+        proxy: '%env(HTTP_PROXY)%'
+        
+        # Request timeout in seconds
+        timeout: 30
+        
+        # Maximum number of redirects
+        max_redirects: 5
+        
+        # Custom headers
+        headers:
+            'User-Agent': 'MyApp/1.0'
+        
+        # Any other Symfony HTTP client option
+        verify_peer: true
+        verify_host: true
+```
+
+This is particularly useful for:
+- Corporate environments with proxy requirements
+- Applications with specific network configurations
+- Custom timeout requirements for slow networks
+- Adding custom headers for monitoring or tracking
+
 ## 🛠️ Use Cases
 
 This bundle is perfect for:
@@ -93,6 +130,12 @@ perspective_api:
     
     # Optional: Custom threshold provider service
     # threshold_provider: 'my.custom.threshold.provider'
+    
+    # Optional: HTTP client options (proxy, timeout, etc.)
+    # http_client_options:
+    #     proxy: 'http://proxy.example.com:8080'
+    #     timeout: 30
+    #     max_redirects: 5
 ```
 
 ### Environment Variables
@@ -100,6 +143,10 @@ perspective_api:
 ```bash
 # .env.local
 PERSPECTIVE_API_KEY=your_api_key_here
+
+# Optional: HTTP proxy configuration
+HTTP_PROXY=http://proxy.example.com:8080
+HTTPS_PROXY=http://proxy.example.com:8080
 ```
 
 ## 📖 Usage

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -49,6 +49,10 @@ class Configuration implements ConfigurationInterface
                     ->scalarPrototype()->end()
                     ->defaultValue(['TOXICITY', 'SEVERE_TOXICITY', 'IDENTITY_ATTACK', 'INSULT', 'PROFANITY', 'THREAT'])
                 ->end()
+                ->arrayNode('http_client_options')
+                    ->info('Additional options for HTTP client (proxy, timeout, etc.)')
+                    ->variablePrototype()->end()
+                ->end()
             ->end();
 
         return $treeBuilder;


### PR DESCRIPTION
This pull request introduces support for advanced HTTP client configuration in the Perspective API Symfony bundle, making it easier to customize network behavior for different environments. The main changes include updates to the documentation, configuration files, and service logic to allow users to specify HTTP client options such as proxies, timeouts, and custom headers.

**Documentation and Configuration Enhancements:**

* Added a new "Advanced Configuration" section to `README.md`, detailing how to set HTTP client options (e.g., proxy, timeout, headers) via the bundle configuration.
* Updated example configuration in `README.md` to show how to use `http_client_options` and related environment variables for proxy settings.

**Codebase Updates for HTTP Client Options:**

* Extended the configuration tree in `src/DependencyInjection/Configuration.php` to support a new `http_client_options` array node for passing additional options to the HTTP client.
* Added a `httpClientOptions` property to `PerspectiveApiService` and initialized it from the configuration in the constructor. [[1]](diffhunk://#diff-4bc5cee33654e22cca9eef257a69439f15c3f70964fa4c8704241ae071e94bfaR44) [[2]](diffhunk://#diff-4bc5cee33654e22cca9eef257a69439f15c3f70964fa4c8704241ae071e94bfaR58)
* Updated the API request logic in `PerspectiveApiService` to merge user-defined `http_client_options` with default request options, allowing for flexible customization of HTTP requests.…vice configuration